### PR TITLE
DOCS - Add Discord application as a requirement in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Blog for DevTalles community.
 
 - **[Node.js](https://nodejs.org/) -** (v22.18.0 or higher)
 - **[pnpm](https://pnpm.io/) -** (v10.15.0 or higher)
+- **[Discord Application (for authenticating users via Discord)](https://github.com/Juansecu/DevTalles-Community-Blog/wiki/setting-up-discord-oauth2)**
 
 ### For Development
 


### PR DESCRIPTION
Add Discord application as a requirement for authenticating users via Discord in README.md file.